### PR TITLE
Add CVE-2022-2385

### DIFF
--- a/vulnerabilities/cve-2022-2385.yaml
+++ b/vulnerabilities/cve-2022-2385.yaml
@@ -5,24 +5,26 @@ cves:
 affectedPlatforms:
 - AWS
 affectedServices:
-- Elastic Kubernetes Service
-image: https://7903508.fs1.hubspotusercontent-na1.net/hub/7903508/hubfs/Group%20102.png?width=1040&name=Group%20102.png
+- EKS
+image: https://cdn.pixabay.com/photo/2019/09/25/09/50/biometrics-4503187_960_720.jpg
 severity: high
 discoveredBy:
   name: Gafnit Amiga
   org: Lightspin
-  domain: lightspin.io
-  twitter: https://mobile.twitter.com/gafnitav
-disclosedAt: 2022/07/11
-exploitabilityPeriod: null
+  domain: https://www.lightspin.io/
+  twitter: gafnitav
+disclosedAt: 2022/05/25
+exploitabilityPeriod: Oct 2017 - June 2022
 knownITWExploitation: null
 summary: |
+  Amazon Elastic Kubernetes Service (EKS) uses IAM to provide authentication to the cluster through the AWS IAM Authenticator for Kubernetes (aws-iam-authenticator).
+  aws-iam-authenticator can be installed on any Kubernetes cluster, and it is installed by default in any EKS cluster both on AWS cloud and on-premises (Amazon EKS Anywhere).
   A security issue was discovered in aws-iam-authenticator where an allow-listed IAM identity may be able to modify their username and escalate privileges.
+  The bug allowed an attacker to (1) craft a malicious token with any action value, (2) without signing the cluster ID, (3) that would manipulate the AccessKeyID value.
 manualRemediation: |
-  Upgrading to v0.5.9 mitigates this vulnerability.
-
-  Prior to upgrading, this vulnerability can be mitigated by not using the {{AccessKeyID}} template value to construct usernames. 
-detectionMethods: This issue affected the logged identity, and is not discernible from valid requests.
+  Upgrading aws-iam-authenticator to v0.5.9 mitigates this vulnerability.
+  As a workaround, this vulnerability can be mitigated by not using the {{AccessKeyID}} template value to construct usernames. 
+detectionMethods: None - this issue affected the logged identity, and is not discernible from valid requests.
 contributor: https://github.com/patricksanders
 references:
 - https://blog.lightspin.io/exploiting-eks-authentication-vulnerability-in-aws-iam-authenticator

--- a/vulnerabilities/cve-2022-2385.yaml
+++ b/vulnerabilities/cve-2022-2385.yaml
@@ -1,0 +1,30 @@
+title: AWS IAM Authenticator for Kubernetes AccessKeyID Validation Bypass
+slug: CVE-2022-2385
+cves:
+- CVE-2022-2385
+affectedPlatforms:
+- AWS
+affectedServices:
+- Elastic Kubernetes Service
+image: https://7903508.fs1.hubspotusercontent-na1.net/hub/7903508/hubfs/Group%20102.png?width=1040&name=Group%20102.png
+severity: high
+discoveredBy:
+  name: Gafnit Amiga
+  org: Lightspin
+  domain: lightspin.io
+  twitter: https://mobile.twitter.com/gafnitav
+disclosedAt: 2022/07/11
+exploitabilityPeriod: null
+knownITWExploitation: null
+summary: |
+  A security issue was discovered in aws-iam-authenticator where an allow-listed IAM identity may be able to modify their username and escalate privileges.
+manualRemediation: |
+  Upgrading to v0.5.9 mitigates this vulnerability.
+
+  Prior to upgrading, this vulnerability can be mitigated by not using the {{AccessKeyID}} template value to construct usernames. 
+detectionMethods: This issue affected the logged identity, and is not discernible from valid requests.
+contributor: https://github.com/patricksanders
+references:
+- https://blog.lightspin.io/exploiting-eks-authentication-vulnerability-in-aws-iam-authenticator
+- https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/472
+- https://aws.amazon.com/security/security-bulletins/AWS-2022-007/


### PR DESCRIPTION
This PR adds an entry for [CVE-2022-2385](https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/472), found by [Gafnit Amiga from Lightspin](https://blog.lightspin.io/exploiting-eks-authentication-vulnerability-in-aws-iam-authenticator).