### PR TITLE
Added AWS AppSync Confused Deputy vulnerability

### DIFF
--- a/vulnerabilities/aws-appsync-confused-deputy.yaml
+++ b/vulnerabilities/aws-appsync-confused-deputy.yaml
@@ -1,0 +1,27 @@
+title: AWS AppSync Confused Deputy via ServiceRoleArn
+slug: aws-appsync-confused-deputy
+cves: null
+affectedPlatforms:
+- AWS
+affectedServices:
+- AppSync
+image: https://datadog-securitylabs.imgix.net/img/appsync-vulnerability-disclosure/hero.png?h=712&auto=format&dpr=2
+severity: High
+discoveredBy:
+  name: Nick Frichette
+  org: Datadog
+  domain: https://securitylabs.datadoghq.com/
+  twitter: frichette_n
+publishedAt: 2022/11/21
+disclosedAt: 2022/09/01
+exploitabilityPeriod: Before September 6, 2022
+knownITWExploitation: false
+summary: |
+  Prior to September 6, 2022, the AWS AppSync service could be coerced to assume arbitrary roles which trusted the AppSync service. This was due to insufficient validation of a serviceRoleArn parameter, allowing an attacker to specify roles in other accounts. With this vulnerability, an adversary could invoke arbitrary AWS API calls with the compromised role.
+manualRemediation: |
+  None required 
+detectionMethods: Suspicious calls from roles assumed by the AppSync service.
+contributor: https://github.com/frichetten
+references:
+- https://securitylabs.datadoghq.com/articles/appsync-vulnerability-disclosure/
+- https://aws.amazon.com/security/security-bulletins/AWS-2022-009/

--- a/vulnerabilities/aws-appsync-confused-deputy.yaml
+++ b/vulnerabilities/aws-appsync-confused-deputy.yaml
@@ -1,11 +1,11 @@
-title: AWS AppSync Confused Deputy via ServiceRoleArn
+title: AWS AppSync confused deputy via ServiceRoleArn
 slug: aws-appsync-confused-deputy
 cves: null
 affectedPlatforms:
 - AWS
 affectedServices:
 - AppSync
-image: https://datadog-securitylabs.imgix.net/img/appsync-vulnerability-disclosure/hero.png?h=712&auto=format&dpr=2
+image: https://raw.githubusercontent.com/wiz-sec/open-cvdb/main/images/appsync-confused-deputy.jpg
 severity: High
 discoveredBy:
   name: Nick Frichette
@@ -14,10 +14,14 @@ discoveredBy:
   twitter: frichette_n
 publishedAt: 2022/11/21
 disclosedAt: 2022/09/01
-exploitabilityPeriod: Before September 6, 2022
+exploitabilityPeriod: Until 2022/09/06
 knownITWExploitation: false
 summary: |
-  Prior to September 6, 2022, the AWS AppSync service could be coerced to assume arbitrary roles which trusted the AppSync service. This was due to insufficient validation of a serviceRoleArn parameter, allowing an attacker to specify roles in other accounts. With this vulnerability, an adversary could invoke arbitrary AWS API calls with the compromised role.
+  Prior to September 6, 2022, the AWS AppSync service could be coerced
+  to assume arbitrary roles which trusted the AppSync service. This was
+  due to insufficient validation of a serviceRoleArn parameter, allowing
+  an attacker to specify roles in other accounts. With this vulnerability,
+  an adversary could invoke arbitrary AWS API calls with the compromised role.
 manualRemediation: |
   None required 
 detectionMethods: Suspicious calls from roles assumed by the AppSync service.


### PR DESCRIPTION
Hey there. This PR submits a [confused deputy vulnerability in AWS AppSync](https://securitylabs.datadoghq.com/articles/appsync-vulnerability-disclosure/), that I found. This would allow you to access resources in other AWS accounts by tricking the AppSync service to assume arbitrary roles which trust it.

I have marked it as a High. Not entirely sure what constitutes a Critical. I'm open to changes/feedback though :)