### PR TITLE
Remove criteria statement 

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -22,7 +22,6 @@ Examples include:
 
 We consider the following cases to be out of scope of this project:
 -	Cloud vulnerabilities or security issues about which there is no publicly available information
--	CSP security incidents with no security impact on customers
 -	CSP customer security incidents
 
 ### History


### PR DESCRIPTION
Remove the criteria statement requiring there to be a customer impact. I believe we should track all security incidents at the cloud providers, whether or not it ended up impacting customers.