### PR TITLE
Added Cloudtrail bypass for both read and write actions in AWS Service Catalog

### DIFF
--- a/vulnerabilities/aws-service-catalog-cloudtrail-bypass.yaml
+++ b/vulnerabilities/aws-service-catalog-cloudtrail-bypass.yaml
@@ -1,12 +1,12 @@
-title: AWS CloudTrail bypass for Service Catalog
+title: CloudTrail bypass for AWS Service Catalog
 slug: aws-service-catalog-cloudtrail-bypass
 cves: null
 affectedPlatforms:
 - AWS
 affectedServices:
 - Service Catalog
-image: <fill in please>
-severity: Low
+image: https://raw.githubusercontent.com/wiz-sec/open-cvdb/main/images/aws-service-catalog-cloudtrail-bypass.jpg
+severity: Medium
 discoveredBy:
   name: Nick Frichette
   org: Datadog
@@ -17,7 +17,10 @@ disclosedAt: 2023/01/30
 exploitabilityPeriod: Until 2023/02/07
 knownITWExploitation: false
 summary: |
-  Due to an exposed development endpoint, it was possible to bypass CloudTrail logging for both read and write API actions for the Service Catalog service. This could have enabled adversaries to alter Service Catalog resources undetected after gaining a foothold in a victim AWS environment.
+  Due to an exposed development endpoint, it was possible to bypass CloudTrail
+  logging for both read and write API actions for the Service Catalog service.
+  This could have enabled adversaries to alter Service Catalog resources undetected
+  after gaining a foothold in a victim AWS environment.
 manualRemediation: |
   None required
 detectionMethods: null

--- a/vulnerabilities/aws-service-catalog-cloudtrail-bypass.yaml
+++ b/vulnerabilities/aws-service-catalog-cloudtrail-bypass.yaml
@@ -1,0 +1,26 @@
+title: AWS CloudTrail bypass for Service Catalog
+slug: aws-service-catalog-cloudtrail-bypass
+cves: null
+affectedPlatforms:
+- AWS
+affectedServices:
+- Service Catalog
+image: <fill in please>
+severity: Low
+discoveredBy:
+  name: Nick Frichette
+  org: Datadog
+  domain: https://securitylabs.datadoghq.com/
+  twitter: frichette_n
+publishedAt: 2023/03/19
+disclosedAt: 2023/01/30
+exploitabilityPeriod: Until 2023/02/07
+knownITWExploitation: false
+summary: |
+  Due to an exposed development endpoint, it was possible to bypass CloudTrail logging for both read and write API actions for the Service Catalog service. This could have enabled adversaries to alter Service Catalog resources undetected after gaining a foothold in a victim AWS environment.
+manualRemediation: |
+  None required
+detectionMethods: null
+contributor: https://github.com/frichetten
+references:
+- https://securitylabs.datadoghq.com/articles/bypass-cloudtrail-aws-service-catalog-and-other/


### PR DESCRIPTION
We just publicly disclosed this vulnerability in AWS Service Catalog. By abusing a dev endpoint you could bypass CloudTrail logging for both read AND write actions in Service Catalog.

## Disclosure Timeline
January 30, 2023: Datadog reports both issues to AWS.
January 30, 2023: AWS responds that they received the report.
February 7, 2023: AWS confirms that a fix is in development.
February 7, 2023: AWS deploys fix to Service Catalog.
March 20, 2023: Datadog releases public disclosure.