### PR TITLE
Added missing CloudTrail logging bug in AWS Control Tower

### DIFF
--- a/vulnerabilities/aws-control-tower-lack-of-cloudtrail-logging.yaml
+++ b/vulnerabilities/aws-control-tower-lack-of-cloudtrail-logging.yaml
@@ -1,11 +1,11 @@
-title: Lack of CloudTrail Logging in AWS Control Tower
+title: Partial CloudTrail logging in AWS Control Tower
 slug: aws-control-tower-lack-of-cloudtrail-logging
 cves: null
 affectedPlatforms:
 - AWS
 affectedServices:
 - Control Tower
-image: <fill in please> 
+image: https://raw.githubusercontent.com/wiz-sec/open-cvdb/main/images/aws-control-tower-lack-of-cloudtrail-logging.jpg
 severity: Low
 discoveredBy:
   name: Nick Frichette
@@ -17,7 +17,11 @@ disclosedAt: 2023/01/30
 exploitabilityPeriod: Until 2023/02/13
 knownITWExploitation: false
 summary: |
-  AWS Control Tower was not properly logging to CloudTrail when API calls failed due to a lack of permissions.
+  AWS Control Tower was not properly logging to CloudTrail when API calls
+  failed due to a lack of permissions. This could have enabled adversaries
+  to remain undetected after gaining a foothold in a victim AWS environment,
+  since any unsuccessful API calls would not be logged, which might include
+  enumeration of privileges.
 manualRemediation: |
   None required
 detectionMethods: null

--- a/vulnerabilities/aws-control-tower-lack-of-cloudtrail-logging.yaml
+++ b/vulnerabilities/aws-control-tower-lack-of-cloudtrail-logging.yaml
@@ -1,0 +1,26 @@
+title: Lack of CloudTrail Logging in AWS Control Tower
+slug: aws-control-tower-lack-of-cloudtrail-logging
+cves: null
+affectedPlatforms:
+- AWS
+affectedServices:
+- Control Tower
+image: <fill in please> 
+severity: Low
+discoveredBy:
+  name: Nick Frichette
+  org: Datadog
+  domain: https://securitylabs.datadoghq.com/
+  twitter: frichette_n
+publishedAt: 2023/03/20
+disclosedAt: 2023/01/30
+exploitabilityPeriod: Until 2023/02/13
+knownITWExploitation: false
+summary: |
+  AWS Control Tower was not properly logging to CloudTrail when API calls failed due to a lack of permissions.
+manualRemediation: |
+  None required
+detectionMethods: null
+contributor: https://github.com/frichetten
+references:
+- https://securitylabs.datadoghq.com/articles/bypass-cloudtrail-aws-service-catalog-and-other/

--- a/vulnerabilities/aws-control-tower-lack-of-cloudtrail-logging.yaml
+++ b/vulnerabilities/aws-control-tower-lack-of-cloudtrail-logging.yaml
@@ -18,10 +18,10 @@ exploitabilityPeriod: Until 2023/02/13
 knownITWExploitation: false
 summary: |
   AWS Control Tower was not properly logging to CloudTrail when API calls
-  failed due to a lack of permissions. This could have enabled adversaries
-  to remain undetected after gaining a foothold in a victim AWS environment,
-  since any unsuccessful API calls would not be logged, which might include
-  enumeration of privileges.
+  failed due to a lack of permissions. This could have helped an adversary
+  with existing access to a victim AWS environment avoid detection while
+  enumerating privileges, since any unsuccessful API calls would not
+  generate "access denied" log entries.
 manualRemediation: |
   None required
 detectionMethods: null


### PR DESCRIPTION
We just disclosed this bug in AWS Control Tower. Due to reasons unknown, API calls which failed due to a lack of permissions were not logged to CloudTrail. As a result, this would (for lack of a better term) give an adversary a free-try to interact with Control Tower, and if they didn't have permission, it would not get logged.

## Disclosure Timeline
January 30, 2023: Datadog reports both issues to AWS.
January 30, 2023: AWS responds that they received the report.
February 7, 2023: AWS confirms that a fix is in development.
February 13, 2023: AWS deploys fix to Control Tower.
March 20, 2023: Datadog releases public disclosure.

Totally okay if this does not meet the bar for the site. This is definitely a very minor issue.