### PR TITLE
Add app runner list vpc connectors for account

### DIFF
--- a/vulnerabilities/aws-app-runner-list-vpc-connectors-for-account.yaml
+++ b/vulnerabilities/aws-app-runner-list-vpc-connectors-for-account.yaml
@@ -1,0 +1,30 @@
+title: AWS App Runner Cross-Tenant Information Leak (ListVpcConnectorsForAccount)
+slug: aws-app-runner-list-vpc-connectors-for-account
+cves: null
+affectedPlatforms:
+- AWS
+affectedServices:
+- App Runner
+image: <Please Fill In>
+severity: Low
+discoveredBy:
+  name: Nick Frichette
+  org: Nick Frichette
+  domain: https://frichetten.com
+  twitter: frichette_n
+publishedAt: 2023/04/03
+disclosedAt: 2023/02/28
+exploitabilityPeriod: Until 2023/03/13
+knownITWExploitation: false
+summary: |
+  The API action ListVpcConnectorsForAccount did not properly validate the "AccountId" parameter
+  that was passed to it. As a result, any account ID could be provided and the API would return
+  the information for that account. This would leak minor information about the VPC 
+  configuration for App Runner in the account including the subnet ID, security group ID, and the
+  VPC Connector ARN.
+manualRemediation: |
+  None required
+detectionMethods: null
+contributor: https://github.com/frichetten
+references:
+- https://frichetten.com/blog/minor-cross-tenant-vulns-app-runner


### PR DESCRIPTION
A minor vulnerability I found in AWS App Runner. [Source](https://frichetten.com/blog/minor-cross-tenant-vulns-app-runner/).