### PR TITLE
Added amplify vulnerability

### DIFF
--- a/vulnerabilities/aws-amplify-iam-role-publicly-assumable-exposure.yaml
+++ b/vulnerabilities/aws-amplify-iam-role-publicly-assumable-exposure.yaml
@@ -1,0 +1,33 @@
+title: AWS Amplify IAM role publicly assumable exposure
+slug: aws-amplify-iam-role-publicly-assumable-exposure
+cves: CVE-2024-28056
+affectedPlatforms:
+  - AWS
+affectedServices:
+  - Amplify
+  - Cognito
+image: 
+severity: Critical
+discoveredBy:
+  name: Nick Frichette
+  org: Datadog
+  domain: https://securitylabs.datadoghq.com/
+  twitter: frichette_n
+publishedAt: 2024/04/15
+disclosedAt: 2024/01/09
+exploitabilityPeriod: Between July 2018 and January 2024
+knownITWExploitation: false
+summary: |
+  The AWS Amplify service was found to be misconfiguring IAM roles associated 
+  with Amplify projects. This misconfiguration caused these roles to be assumable 
+  by any other AWS account. Both the Amplify Studio and the Amplify CLI 
+  exhibited this behavior. 
+manualRemediation: |
+  None required 
+detectionMethods: |
+  Review CloudTrail logs for suspicious sts:AssumeRoleWithWebIdentity API calls in which 
+  the identity pool ID is not owned by an identity pool in the same account.
+contributor: https://github.com/frichetten
+references:
+- https://securitylabs.datadoghq.com/articles/amplified-exposure-how-aws-flaws-made-amplify-iam-roles-vulnerable-to-takeover/
+- https://aws.amazon.com/security/security-bulletins/AWS-2024-003/

--- a/vulnerabilities/aws-amplify-iam-role-publicly-assumable-exposure.yaml
+++ b/vulnerabilities/aws-amplify-iam-role-publicly-assumable-exposure.yaml
@@ -6,7 +6,7 @@ affectedPlatforms:
 affectedServices:
   - Amplify
   - Cognito
-image: 
+image: https://images.unsplash.com/photo-1615297658577-dc5cec88e81a?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
 severity: Critical
 discoveredBy:
   name: Nick Frichette
@@ -21,9 +21,14 @@ summary: |
   The AWS Amplify service was found to be misconfiguring IAM roles associated 
   with Amplify projects. This misconfiguration caused these roles to be assumable 
   by any other AWS account. Both the Amplify Studio and the Amplify CLI 
-  exhibited this behavior. 
+  exhibited this behavior. Any Amplify project created using the Amplify CLI
+  built between July 3, 2018 and August 8, 2019 had IAM roles that were assumable by
+  anyone in the world. AWS mitigated this vulnerability through backend changes to
+  STS and IAM, and also released a patch for the Amplify CLI to ensure that newly
+  created roles are properly configured in accordance with these changes.
 manualRemediation: |
-  None required 
+  None required, but customers should upgrade to Amplify CLI 12.10.1 or higher to
+  ensure that newly created roles are compatible with the backend mitigations.
 detectionMethods: |
   Review CloudTrail logs for suspicious sts:AssumeRoleWithWebIdentity API calls in which 
   the identity pool ID is not owned by an identity pool in the same account.


### PR DESCRIPTION
:wave: Hey friends.

New vulnerability in AWS Amplify. It exposed IAM roles associated with Amplify projects to takeover. 

Details here: https://securitylabs.datadoghq.com/articles/amplified-exposure-how-aws-flaws-made-amplify-iam-roles-vulnerable-to-takeover/
AWS Security Bulletin here: https://aws.amazon.com/security/security-bulletins/AWS-2024-003/