### PR TITLE
Added Piercing Index version 1.6.1

### DIFF
--- a/vulnerabilities/global-admin-entra-id-actor-tokens.yaml
+++ b/vulnerabilities/global-admin-entra-id-actor-tokens.yaml
@@ -7,6 +7,7 @@ affectedPlatforms:
 affectedServices: []
 image:
 severity: critical
+piercingIndexVector: {version: 1.6.1, A1: 22, A2: 1.21, A7: 1.1, A8: 1.1, A9:1.1}
 discoveredBy:
   name: Dirk-jan Mollema
   org: Outsider Security


### PR DESCRIPTION
Please note that a new question, A9, has been added to the Piercing Index (version 1.6.1): it is explained in the Issue  just opened.

The reason why we need A9 is because the Actor Token vulnerability leaves no audit logs in Azure Entra

Thanks!