### PR TITLE
Add Vertex AI Experiments bucket squatting entry (CVE-2026-2473)

### DIFF
--- a/vulnerabilities/vertex-ai-bucket-squatting.yaml
+++ b/vulnerabilities/vertex-ai-bucket-squatting.yaml
@@ -1,0 +1,28 @@
+title: Vertex AI Experiments Cross-Tenant RCE via Bucket Squatting
+slug: vertex-ai-bucket-squatting
+cves:
+  - CVE-2026-2473
+affectedPlatforms:
+  - gcp
+affectedServices:
+  - Vertex AI Experiments
+image: null
+severity: critical
+discoveredBy:
+  name: null
+  org: null
+  domain: null
+  twitter: null
+publishedAt: 2026/02/20
+disclosedAt: null
+exploitabilityPeriod: null
+knownITWExploitation: false
+summary: |
+  A vulnerability in Vertex AI Experiments allowed unauthenticated remote attackers to achieve cross-tenant remote code execution, model theft, and model poisoning through pre-creating predictably named Cloud Storage buckets (bucket squatting). Attackers could exploit the predictable bucket naming scheme in Vertex AI Experiments versions 1.21.0 through 1.132.x to gain unauthorized access across customer boundaries. Google addressed the vulnerability in version 1.133.0 with mitigations applied server-side.
+manualRemediation: |
+  None required. Mitigations were applied starting with version 1.133.0 and later.
+detectionMethods: null
+contributor: https://github.com/ramimac
+references:
+  - https://cloud.google.com/support/bulletins#gcp-2026-012
+entryStatus: Stub (AI-Generated)


### PR DESCRIPTION
## Summary
- **Vulnerability**: Vertex AI Experiments Cross-Tenant RCE via Bucket Squatting
- **CVE**: CVE-2026-2473
- **Severity**: Critical
- **Source**: GCP Security Bulletin GCP-2026-012

Cross-tenant remote code execution, model theft, and poisoning via predictable Cloud Storage bucket naming.

## Entry Status
Stub (AI-Generated) - requires human review before finalizing.

---
Generated with Claude Code /hunt