### PR TITLE
Add Claude Code skills for vulnerability management (updated)

### DIFF
--- a/.claude/commands/hunt.md
+++ b/.claude/commands/hunt.md
@@ -45,6 +45,35 @@ These are the most authoritative sources - official vendor acknowledgments.
 2. For recent months, fetch `/cvrf/{id}` (e.g., `/cvrf/2026-Apr`)
 3. Filter for Azure/Entra/M365 products in the CVRF response
 4. Cross-reference CVEs with existing entries
+5. **Enrich with NVD data** (see below)
+
+### Enriching MSRC CVEs with NVD Data
+
+MSRC's CVRF data provides CVE IDs and CVSS scores, but descriptions are often generic (e.g., "high impact to confidentiality"). The NVD API provides better technical descriptions and CWE classifications.
+
+**NVD API Endpoint:**
+```
+https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-YYYY-NNNNN
+```
+
+**For each MSRC CVE, fetch NVD data to get:**
+- **Description**: Actual vulnerability type (e.g., "Server-side request forgery allows...")
+- **CWE ID**: Weakness classification (e.g., CWE-918 for SSRF, CWE-285 for Improper Authorization)
+
+**Use in entry:**
+- Title: Include vulnerability type from NVD (e.g., "Azure Databricks SSRF Privilege Escalation")
+- Summary: Lead with NVD description and CWE, then add CVSS context
+- References: Include both MSRC and NVD URLs
+
+**Example summary using NVD data:**
+```
+A server-side request forgery (SSRF) vulnerability (CWE-918) in Azure Databricks 
+allowed unauthorized attackers to elevate privileges over a network. Microsoft 
+assigned a CVSS score of 10.0. The vulnerability was addressed in Microsoft's 
+April 2026 security updates.
+```
+
+**Note:** NVD data may lag MSRC announcements by hours or days. If NVD returns no results, create an issue instead of a PR, noting that NVD enrichment is pending.
 
 ### Tier 2: Security Research Firms (High Authority)
 

--- a/.claude/commands/hunt.md
+++ b/.claude/commands/hunt.md
@@ -1,0 +1,203 @@
+---
+name: hunt
+description: Hunt for new cloud vulnerabilities to add to open-cvdb. Checks authoritative security research sources for recent disclosures, or reviews a specific URL provided as argument. Creates PRs for well-documented vulnerabilities or opens GitHub issues when more details are needed. Use when asked to find new vulnerabilities, check for updates, or review a specific security blog/bulletin.
+---
+
+# Vulnerability Hunt Skill
+
+Proactively find new cloud vulnerabilities to add to the database.
+
+## Usage
+
+**Check authoritative sources for new vulnerabilities:**
+```
+/hunt
+```
+
+**Review a specific URL:**
+```
+/hunt https://example.com/blog/cloud-vuln
+```
+
+## Authoritative Sources
+
+### Tier 1: Vendor Security Bulletins (Check First)
+
+These are the most authoritative sources - official vendor acknowledgments.
+
+| Vendor | URL | Check Method |
+|--------|-----|--------------|
+| AWS | https://aws.amazon.com/security/security-bulletins/ | Fetch page, look for bulletins not in CVDB |
+| GCP | https://cloud.google.com/support/bulletins | Fetch page, look for cloud-specific bulletins |
+| Azure/MSRC | https://msrc.microsoft.com/update-guide/ | Search for Azure/Entra/M365 advisories |
+| GitHub | https://github.blog/security/ | Check for platform security posts |
+
+### Tier 2: Security Research Firms (High Authority)
+
+Established firms with track records of responsible disclosure.
+
+| Source | Domain | Focus |
+|--------|--------|-------|
+| Wiz | wiz.io/blog | AWS, Azure, GCP cross-tenant issues |
+| Orca Security | orca.security/resources/blog | Multi-cloud vulnerabilities |
+| Tenable | tenable.com/blog/search?field_blog_section_tid=453 | Cloud security research |
+| Palo Alto Unit42 | unit42.paloaltonetworks.com | Cloud threat research |
+| Datadog Security Labs | securitylabs.datadoghq.com | AWS, container security |
+| Aqua Security | aquasec.com/blog | Container, Kubernetes, cloud |
+| NetSPI | netspi.com/blog | Cloud penetration testing |
+| Rhino Security Labs | rhinosecuritylabs.com/blog | AWS, cloud attack research |
+| Lightspin | blog.lightspin.io | AWS security |
+| TrustOnCloud | trustoncloud.com/blog | AWS IAM, Bedrock |
+| Legit Security | legitsecurity.com/blog | CI/CD, supply chain |
+| Praetorian | praetorian.com/blog | Azure, cloud security |
+
+### Tier 3: Independent Researchers (Frequently Cited)
+
+Individual researchers with established credibility in cloud security.
+
+| Researcher | Domain | Known For |
+|------------|--------|-----------|
+| Nick Frichette | frichetten.com | AWS exploitation, Hacking the Cloud |
+| Christophe Tafani-Dereeper | blog.christophetd.fr | AWS, GCP research |
+| embracethered | embracethered.com | Azure, M365 security |
+| binarysecurity.no | binarysecurity.no | Azure security |
+| Scott Piper | summitroute.com | AWS security, original CSP mistakes list |
+| Dirk-jan Mollema | dirkjanm.io | Azure AD/Entra ID |
+
+## Process
+
+### Mode 1: Check Sources (no argument)
+
+When invoked without a URL:
+
+1. **Select sources to check** - Ask user which tier(s) to check, or check all
+2. **Fetch recent posts** from each source's blog/bulletin page
+3. **Filter for cloud vulnerabilities** - Look for:
+   - AWS, Azure, GCP, GitHub, GitLab mentions
+   - CVE assignments for cloud services
+   - Terms: vulnerability, security issue, disclosure, cross-tenant, privilege escalation
+4. **Cross-reference with existing entries** - Check if already in CVDB
+5. **For each new finding**, run the vulnerability skill process
+
+### Mode 2: Review URL (with argument)
+
+When invoked with a URL argument:
+
+1. **Fetch and analyze** the provided URL
+2. **Run vulnerability skill** - full analysis including:
+   - Scope check (is it a cloud CSP vulnerability?)
+   - Duplicate check
+   - Source corroboration
+   - Skeptical impact review
+3. **Create PR or Issue** based on findings
+
+## Output Handling
+
+### Sufficient Information → Create PR
+
+If the vulnerability skill succeeds (passes all checks), create a PR via the vulnerability skill.
+
+**Always set `entryStatus: Stub (AI-Generated)`** - even if information appears complete, human review is required before marking as Finalized.
+
+### Insufficient Information → Create Issue
+
+If we find a potential vulnerability but lack details, create a GitHub issue:
+
+```bash
+gh issue create --repo wiz-sec/open-cvdb \
+  --label "addition" \
+  --title "[Contribution] {vulnerability_title}" \
+  --body "## Summary
+{brief_description}
+
+## References
+{source_urls}
+
+## Notes
+This vulnerability was identified during automated hunting but requires additional information:
+- {what's_missing}
+
+## Source Authority
+{authority_assessment}
+
+---
+*Created by automated hunt. Human review needed to complete entry.*"
+```
+
+**Create an issue when:**
+- Source is behind paywall but title/abstract indicates cloud vuln
+- Vulnerability is mentioned but technical details are sparse
+- No vendor acknowledgment yet but research looks credible
+- Date/timeline information is unclear
+
+### Out of Scope → Skip
+
+If the finding is out of scope for CVDB:
+- Customer incidents, WAF bypasses, non-cloud vulns
+- Log it in the hunt summary but don't create PR or issue
+
+### Already Exists → Skip
+
+If already in CVDB:
+- Note as "already tracked" in summary
+- Optionally flag if existing entry needs updates
+
+## Hunt Summary
+
+After checking sources, provide a summary:
+
+```markdown
+## Hunt Summary
+
+**Sources checked**: {n}
+**New vulnerabilities found**: {n}
+**PRs created**: {n}
+**Issues created**: {n}
+**Already tracked**: {n}
+**Out of scope**: {n}
+
+### New Findings
+| Source | Vulnerability | Outcome |
+|--------|--------------|---------|
+| Wiz Blog | CosmosDB cross-tenant | PR #123 |
+| AWS Bulletin | ECS agent info disclosure | Already tracked |
+| Unit42 | Lambda cold start timing | Out of scope (not CSP vuln) |
+
+### Issues Created (Need More Info)
+| Issue | Source | What's Missing |
+|-------|--------|----------------|
+| #456 | MSRC advisory | Technical details unclear |
+```
+
+## Rate Limiting
+
+- Check maximum 5 sources per run to avoid overwhelming
+- If more sources need checking, suggest running again
+- Add delay between fetches to be respectful to source sites
+
+## Example
+
+**Hunt all sources:**
+```
+User: /hunt
+Assistant: I'll check the authoritative sources for new cloud vulnerabilities.
+[Checks Tier 1 vendor bulletins first, then Tier 2 research firms]
+[Cross-references findings with existing CVDB entries]
+[Creates PRs for well-documented vulns, issues for those needing more info]
+```
+
+**Review specific URL:**
+```
+User: /hunt https://wiz.io/blog/new-azure-vulnerability
+Assistant: I'll analyze this Wiz blog post for a potential CVDB entry.
+[Runs vulnerability skill on the URL]
+[Creates PR if sufficient info, or issue if more details needed]
+```
+
+## Integration with Other Skills
+
+This skill uses:
+- **vulnerability skill** - For full analysis and PR creation
+- **triage-issues skill** - Similar output format for issues created
+
+When creating issues, use the same format as contribution issues so triage-issues can process them later if more information becomes available.

--- a/.claude/commands/hunt.md
+++ b/.claude/commands/hunt.md
@@ -7,6 +7,14 @@ description: Hunt for new cloud vulnerabilities to add to open-cvdb. Checks auth
 
 Proactively find new cloud vulnerabilities to add to the database.
 
+## Access Requirements
+
+This skill works for both contributors and non-contributors:
+- **Source fetching**: No GitHub access required
+- **Duplicate checking**: Uses local grep, no special access needed
+- **Issue creation**: Any authenticated GitHub user can create issues on public repos
+- **PR creation**: Handled by the vulnerability skill, which supports fork-based workflows
+
 ## Usage
 
 **Check authoritative sources for new vulnerabilities:**
@@ -27,10 +35,16 @@ These are the most authoritative sources - official vendor acknowledgments.
 
 | Vendor | URL | Check Method |
 |--------|-----|--------------|
-| AWS | https://aws.amazon.com/security/security-bulletins/ | Fetch page, look for bulletins not in CVDB |
-| GCP | https://cloud.google.com/support/bulletins | Fetch page, look for cloud-specific bulletins |
-| Azure/MSRC | https://msrc.microsoft.com/update-guide/ | Search for Azure/Entra/M365 advisories |
+| AWS | https://aws.amazon.com/security/security-bulletins/feed/ | Fetch RSS feed (works better than web page) |
+| GCP | https://cloud.google.com/support/bulletins | Fetch page (redirects to docs.cloud.google.com) |
+| Azure/MSRC | https://api.msrc.microsoft.com/cvrf/v3.0/updates | Use MSRC API, then fetch /cvrf/{yyyy-Mon} for details |
 | GitHub | https://github.blog/security/ | Check for platform security posts |
+
+**MSRC API Usage:**
+1. Fetch `/updates` to get list of monthly security updates
+2. For recent months, fetch `/cvrf/{id}` (e.g., `/cvrf/2026-Apr`)
+3. Filter for Azure/Entra/M365 products in the CVRF response
+4. Cross-reference CVEs with existing entries
 
 ### Tier 2: Security Research Firms (High Authority)
 

--- a/.claude/commands/hunt.md
+++ b/.claude/commands/hunt.md
@@ -107,6 +107,29 @@ Individual researchers with established credibility in cloud security.
 | Scott Piper | summitroute.com | AWS security, original CSP mistakes list |
 | Dirk-jan Mollema | dirkjanm.io | Azure AD/Entra ID |
 
+## Duplicate Prevention (CRITICAL)
+
+Before creating any PR or issue, check ALL of these:
+
+1. **Existing entries in repo** - grep for CVE ID, service name, vulnerability name
+   ```bash
+   grep -ri "CVE-2026-12345" vulnerabilities/
+   grep -ri "service-name" vulnerabilities/
+   ```
+
+2. **ALL open PRs** (not just your own - PRs may come from different accounts/forks):
+   ```bash
+   gh pr list --repo wiz-sec/open-cvdb --state open --json number,title --limit 50
+   ```
+   Search the titles for CVE IDs, service names, or vulnerability keywords.
+
+3. **Open issues** - may indicate work in progress:
+   ```bash
+   gh issue list --repo wiz-sec/open-cvdb --label addition --state open --json number,title
+   ```
+
+**Why this matters:** Fork accounts can change between sessions. A PR opened from `user-a/repo` won't show up when filtering by `--author user-b`. Always check ALL open PRs regardless of author.
+
 ## Process
 
 ### Mode 1: Check Sources (no argument)
@@ -119,7 +142,7 @@ When invoked without a URL:
    - AWS, Azure, GCP, GitHub, GitLab mentions
    - CVE assignments for cloud services
    - Terms: vulnerability, security issue, disclosure, cross-tenant, privilege escalation
-4. **Cross-reference with existing entries** - Check if already in CVDB
+4. **Cross-reference with existing entries AND open PRs** - Check if already in CVDB or pending
 5. **For each new finding**, run the vulnerability skill process
 
 ### Mode 2: Review URL (with argument)
@@ -181,9 +204,10 @@ If the finding is out of scope for CVDB:
 
 ### Already Exists → Skip
 
-If already in CVDB:
-- Note as "already tracked" in summary
+If already in CVDB **OR has an open PR/issue**:
+- Note as "already tracked" or "PR pending" in summary
 - Optionally flag if existing entry needs updates
+- Do NOT create duplicate PRs even if from different fork accounts
 
 ## Hunt Summary
 

--- a/.claude/commands/triage-issues.md
+++ b/.claude/commands/triage-issues.md
@@ -11,6 +11,13 @@ Automatically triage open issues requesting new vulnerability additions.
 
 This skill processes open issues with the "addition" label, extracts source URLs, runs the vulnerability skill to evaluate them, and either creates a PR or comments with analysis explaining why not.
 
+## Access Requirements
+
+This skill works for both contributors and non-contributors:
+- **Read operations** (issue list, PR list, comments): Work for any authenticated GitHub user
+- **Issue comments**: Any authenticated user can comment on public repo issues
+- **PR creation**: Handled by the vulnerability skill, which supports fork-based workflows for non-contributors
+
 ## Process
 
 ### Step 1: Fetch Open Issues

--- a/.claude/commands/triage-issues.md
+++ b/.claude/commands/triage-issues.md
@@ -1,0 +1,171 @@
+---
+name: triage-issues
+description: Triage open GitHub issues labeled "addition" in the open-cvdb repository. Reviews each issue for vulnerability sources, runs the vulnerability skill, and comments with analysis. Idempotent - skips issues already triaged. Use when asked to triage issues, review additions, or process the issue backlog.
+---
+
+# Issue Triage Skill
+
+Automatically triage open issues requesting new vulnerability additions.
+
+## Overview
+
+This skill processes open issues with the "addition" label, extracts source URLs, runs the vulnerability skill to evaluate them, and either creates a PR or comments with analysis explaining why not.
+
+## Process
+
+### Step 1: Fetch Open Issues
+
+```bash
+gh issue list --repo wiz-sec/open-cvdb --label "addition" --state open --json number,title,body,comments --limit 50
+```
+
+### Step 2: Filter Already-Triaged Issues
+
+For each issue, check if already processed:
+
+1. **Check for triage comment marker** in issue comments:
+   ```
+   <!-- [triage-comment] -->
+   ```
+
+2. **Check for linked PR**:
+   ```bash
+   gh pr list --repo wiz-sec/open-cvdb --search "closes #{issue_number}" --state all
+   ```
+
+If either exists, skip the issue - it's already been triaged.
+
+### Step 3: Process Each Untriaged Issue
+
+For each untriaged issue:
+
+#### 3a. Extract Source URLs
+
+Parse the issue body for:
+- URLs in the "References" section
+- Any URLs pointing to security research (blog posts, bulletins, CVE records)
+- Links in markdown format `[text](url)` or bare URLs
+
+If no URLs found, comment asking for sources and skip to next issue.
+
+#### 3b. Run Vulnerability Skill
+
+For each extracted URL, follow the vulnerability skill process:
+1. Fetch and analyze sources
+2. Check for duplicates
+3. Search for additional sources
+4. Skeptical impact review
+5. Check scope/inclusion criteria
+
+**When creating the PR**, include `Closes #{issue_number}` in the PR body so GitHub auto-links and closes the issue on merge.
+
+#### 3c. Handle Outcome
+
+**If PR is created:**
+- The vulnerability skill handles the PR
+- Reference the issue in the PR body (e.g., "Closes #{issue_number}") so GitHub auto-links
+- Do NOT add a triage comment - the PR linkage is sufficient
+- The issue will show the PR reference automatically
+
+**If entry is rejected:**
+Add a triage comment explaining why:
+
+```markdown
+<!-- [triage-comment] -->
+## Triage Analysis
+
+Unable to create an entry for this submission.
+
+**Reason**: {rejection_reason}
+
+**Details**:
+{detailed_explanation}
+
+**What would help**:
+{suggestions_for_resubmission}
+
+---
+*This is an automated triage. If you believe this analysis is incorrect, please reply with additional information.*
+```
+
+**Rejection reasons to document:**
+- Source unavailable (404, paywall) with no corroborating sources
+- Out of scope (customer incident, WAF bypass, non-cloud vulnerability)
+- Duplicate of existing entry `{slug}`
+- Actively disputed by vendor
+- Insufficient public information
+- Expected behavior, not a vulnerability
+
+**If more information needed:**
+```markdown
+<!-- [triage-comment] -->
+## Triage: More Information Needed
+
+I attempted to analyze this submission but need clarification:
+
+**Issue**: {what's unclear}
+
+**Questions**:
+{specific_questions}
+
+**Found so far**:
+{partial_findings}
+
+---
+*Please reply with the requested information to continue triage.*
+```
+
+### Step 4: Report Summary
+
+After processing all issues, provide a summary:
+
+```
+## Triage Summary
+
+Processed: {n} issues
+- PRs created: {n}
+- Rejected: {n}  
+- Need more info: {n}
+- Already triaged (skipped): {n}
+
+### Issues Processed:
+| Issue | Outcome | Notes |
+|-------|---------|-------|
+| #123  | PR #456 | Created entry for {slug} |
+| #124  | Rejected | Out of scope - customer incident |
+| #125  | Skipped | Already triaged |
+```
+
+## Idempotency
+
+This skill is idempotent:
+- Issues with a `<!-- [triage-comment] -->` marker are skipped (rejected/needs-info)
+- Issues already linked to a PR are skipped (check with `gh pr list --search "closes #{issue}"`)
+- Safe to run multiple times
+- New issues get processed, old ones skipped
+
+## Rate Limiting
+
+- Process maximum 10 issues per run to avoid API limits
+- If more than 10 untriaged issues exist, report this and suggest running again
+
+## Example
+
+User: "triage the open issues"
+
+Response flow:
+1. Fetch open issues with "addition" label
+2. Filter out issues with triage marker
+3. For each untriaged issue:
+   - Extract URLs
+   - Run vulnerability skill
+   - Comment with outcome
+4. Report summary
+
+## Error Handling
+
+If an error occurs processing an issue:
+- Do NOT add triage marker (so it can be retried)
+- Log the error
+- Continue to next issue
+- Include failed issues in summary with error details

--- a/.claude/commands/vulnerability.md
+++ b/.claude/commands/vulnerability.md
@@ -1,0 +1,258 @@
+---
+name: vulnerability
+description: Create cloud vulnerability YAML entries for open-cvdb from source URLs (blog posts, security bulletins, CVE records). Use when the user provides security research links, asks to add a vulnerability, or mentions cloudvulndb. Performs source validation, duplicate checking, and skeptical impact review before generating AI-generated stub entries.
+---
+
+# Vulnerability Entry Creator
+
+Create YAML entries for the Open Cloud Vulnerability Database from source materials.
+
+## Scope (Inclusion Criteria)
+
+Only create entries for vulnerabilities that meet ALL of these criteria:
+
+**In scope:**
+1. Publicly known cloud vulnerabilities or security issues in cloud services
+2. With or without an assigned CVE
+3. Had proven actual or potential impact on cloud customers
+4. Required remediation on either side of the shared responsibility model
+
+**Examples of in-scope issues:**
+- Security issues in CSP-managed services (AWS, Azure, GCP, GitHub, GitLab)
+- Default misconfigurations of CSP-managed services
+- Vulnerabilities in CSP-provided client software
+
+**Out of scope - do NOT create entries for:**
+- Non-public vulnerabilities (no publicly available information)
+- Customer security incidents (breaches from customer misuse/misconfiguration)
+- WAF bypass vulnerabilities
+- Vulnerabilities in customer-deployed software (even if running on cloud)
+- General security research without a specific CSP vulnerability
+- "Expected behavior" that CSPs explicitly document as customer responsibility
+
+If the provided source describes something out of scope, explain why and do not create an entry.
+
+## Input
+
+The user provides one or more source URLs:
+- Security researcher blog posts
+- Vendor security bulletins (AWS, GCP, Azure, MSRC)
+- CVE records
+- Conference presentations or writeups
+
+## Process
+
+Execute these steps in order. Be skeptical throughout - security vendors often overstate findings for marketing purposes.
+
+### Step 1: Fetch and Analyze Sources
+
+For each provided URL:
+1. Fetch the content using WebFetch
+2. Extract key facts: vulnerability description, affected services, dates, researchers, remediation, detection methods
+3. Note the source type and authority level
+
+**Authority hierarchy** (most to least authoritative):
+1. Vendor security bulletins (AWS Security Bulletins, GCP Support Bulletins, MSRC)
+2. CVE records from NVD/MITRE
+3. Established security research firms (Wiz, Tenable, Orca, Palo Alto, etc.)
+4. Independent security researchers with verifiable track records
+5. Anonymous or unverified sources
+
+If the primary source is low-authority, flag this and search for corroborating sources.
+
+**If the primary source is unavailable (404, paywall, etc.):**
+1. Search for the exact vulnerability in other sources (vendor bulletins, CVE records, other coverage)
+2. If found elsewhere, continue with those sources
+3. If NOT found, check if research yielded a DIFFERENT but related vulnerability
+
+**Pivoting to a related vulnerability:**
+If the original source is unavailable but research uncovered a different/related vulnerability:
+1. STOP and clearly inform the user: "The provided URL was unavailable. However, I found a related vulnerability: [description]. Would you like me to create an entry for this instead?"
+2. Use AskUserQuestion to get explicit confirmation before proceeding
+3. If user confirms, treat this as a NEW request - restart from Step 1 with the new sources
+4. This ensures duplicate checks run against the actual vulnerability being created, not the original request
+
+### Step 2: Check for Duplicates
+
+Search the existing vulnerabilities directory:
+```bash
+# Search by CVE if available
+grep -r "CVE-YYYY-NNNNN" vulnerabilities/
+
+# Search by service name
+grep -ri "service-name" vulnerabilities/
+
+# Search by vulnerability name/slug keywords
+ls vulnerabilities/ | grep -i "keyword"
+```
+
+If a duplicate exists, inform the user and offer to update the existing entry instead.
+
+### Step 3: Search for Additional Sources
+
+Use WebSearch to find:
+1. The vendor's official acknowledgment or security bulletin
+2. CVE assignment (if not already known)
+3. Other researchers who wrote about the same issue
+4. Any disputes or corrections to the original research
+
+Add authoritative sources to references. Note any discrepancies between sources.
+
+### Step 4: Skeptical Impact Review
+
+Evaluate claims critically:
+
+**Red flags for overstated impact:**
+- Marketing language ("catastrophic", "affects millions", "worst ever")
+- Vague impact without specific exploitation scenarios
+- No evidence of actual exploitability
+- Theoretical attacks that require implausible preconditions
+- Vendor incentive to overstate (selling a product/service)
+
+**Adjust severity if:**
+- Exploitation requires unlikely conditions → lower severity
+- "Vulnerability" is actually expected behavior or configuration issue → consider excluding
+- Impact is limited to the researcher's own tenant → lower severity
+- No cross-tenant or privilege escalation impact → likely low/medium
+
+**Disputes to check for:**
+- Vendor disagreed with classification
+- Other researchers challenged the findings
+- Issue was later determined to be intended behavior
+- CVE was rejected or disputed
+
+**Rejection criteria** - Do NOT proceed with entry creation if:
+- The vulnerability is actively disputed
+- The primary source is unavailable (404, paywall, etc.) AND no corroborating sources exist
+- The finding appears to be intended behavior, not a vulnerability
+- The source lacks credibility and no authoritative sources corroborate
+
+If rejecting, explain why and stop. Do not create placeholder/stub files for rejected findings.
+
+### Step 5: Generate YAML Entry (only if not rejected)
+
+Create the YAML file following CLAUDE.md schema. Key rules:
+
+**Filename**: `vulnerabilities/{slug}.yaml` where slug is URL-friendly lowercase with hyphens
+
+**Required skepticism in summary:**
+- Describe what was claimed, not what was proven
+- Use "could allow" not "allows" for theoretical impacts
+- Include vendor's response if they disputed severity
+- Keep to 3-5 sentences, factual, no marketing language
+
+**Severity assignment:**
+- Cross-tenant access, RCE, authentication bypass → critical
+- Privilege escalation within tenant, authorization bypass → high  
+- Information disclosure, logging gaps → medium
+- Limited scope, requires specific conditions → low
+- If genuinely uncertain, use null
+
+**Always set:**
+```yaml
+entryStatus: Stub (AI-Generated)
+```
+
+**Date formats:**
+- publishedAt: YYYY/mm/dd (when source was published)
+- disclosedAt: YYYY/mm/dd (when reported to vendor, if known)
+- exploitabilityPeriod: "Until YYYY/mm/dd" or "YYYY/mm/dd to YYYY/mm/dd"
+
+**Platform values** (lowercase):
+- aws, azure, gcp, github, gitlab
+
+**Empty field handling:**
+- CVEs: use `[]` if none, not `null`
+- Other empty fields: use `null` or leave value empty (not `- null`)
+- Domain: bare domain without https:// prefix
+
+### Step 6: Validate YAML
+
+Before proceeding:
+1. Verify slug matches intended filename
+2. Confirm at least one reference URL exists
+3. Check YAML syntax is valid
+
+### Step 7: Create Branch and Commit
+
+Create a feature branch, write the file, and make an atomic commit:
+
+```bash
+# Create branch from main
+git checkout -b vuln/{slug}
+
+# Write the YAML file
+# (use Write tool to create vulnerabilities/{slug}.yaml)
+
+# Stage and commit
+git add vulnerabilities/{slug}.yaml
+git commit -m "Add {slug} vulnerability entry
+
+Source: {primary_source_url}
+Severity: {severity}
+Status: Stub (AI-Generated)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+### Step 8: Confirm Before PR
+
+Use AskUserQuestion to present the entry and ask for confirmation.
+
+**Clearly explain what happened:**
+- If the original source was used: state this
+- If pivoted to a different source: explain what the original URL was, why it failed, and what vulnerability is actually being documented
+- If severity was adjusted: explain the original claim vs. your assessment
+
+**Include in the question:**
+- The full YAML content
+- Source authority assessment
+- Summary of process: "Created branch `vuln/{slug}` with commit {hash}"
+- Any caveats or concerns (low-authority sources, disputed claims, severity adjustments)
+- Suggestions for upgrading from Stub to Finalized
+
+**Ask:** "Ready to open a PR for this vulnerability entry? Reply 'yes' to proceed, 'no' to discard the branch, or provide feedback to revise."
+
+### Step 9: Open PR (only after user confirms)
+
+If user confirms:
+```bash
+git push -u origin vuln/{slug}
+gh pr create --title "Add {title}" --body "## Summary
+- **Vulnerability**: {title}
+- **Severity**: {severity}
+- **Source**: {primary_source_url}
+
+## Entry Status
+Stub (AI-Generated) - requires human review before finalizing.
+
+## Caveats
+{any_concerns_or_notes}
+
+---
+Generated with Claude Code"
+```
+
+If user provides feedback, revise the YAML and amend the commit before asking again.
+
+## Rejection Output
+
+If the finding is rejected (Step 4), explain:
+- Why the entry was not created
+- What would be needed to reconsider (e.g., "provide an archived copy of the source", "find vendor acknowledgment")
+- Do NOT create any files or branches for rejected findings
+
+## Example
+
+User: "Add this vulnerability: https://example.com/blog/cloud-vuln-writeup"
+
+Response flow:
+1. Fetch the blog post
+2. Search for duplicates by CVE/service/keywords
+3. Search for vendor bulletin, CVE record, other coverage
+4. Evaluate claims skeptically - if rejected, explain and stop
+5. Generate YAML with conservative severity
+6. Validate YAML syntax
+7. Create branch `vuln/{slug}` and commit
+8. AskUserQuestion with full entry and caveats
+9. On confirmation, push and open PR

--- a/.claude/commands/vulnerability.md
+++ b/.claude/commands/vulnerability.md
@@ -7,6 +7,35 @@ description: Create cloud vulnerability YAML entries for open-cvdb from source U
 
 Create YAML entries for the Open Cloud Vulnerability Database from source materials.
 
+## Fork Workflow for Non-Contributors
+
+This skill supports both direct contribution (for repo maintainers) and fork-based workflows (for external contributors).
+
+**Determine access level at the start:**
+```bash
+# Check repository permission
+PERMISSION=$(gh repo view wiz-sec/open-cvdb --json viewerPermission --jq '.viewerPermission' 2>/dev/null)
+echo "Permission: $PERMISSION"
+```
+
+- `ADMIN`, `MAINTAIN`, `WRITE` → Direct push to origin
+- `READ` or empty → Fork workflow required
+
+**For fork workflows, set up once:**
+```bash
+# Get GitHub username
+GH_USER=$(gh api user --jq '.login')
+
+# Create fork if it doesn't exist (idempotent)
+gh repo fork wiz-sec/open-cvdb --clone=false 2>/dev/null || true
+
+# Add fork as remote (if not already added)
+git remote get-url fork 2>/dev/null || git remote add fork "https://github.com/${GH_USER}/open-cvdb.git"
+
+# Fetch from fork to ensure it's accessible
+git fetch fork 2>/dev/null || true
+```
+
 ## Scope (Inclusion Criteria)
 
 Only create entries for vulnerabilities that meet ALL of these criteria:
@@ -215,10 +244,39 @@ Use AskUserQuestion to present the entry and ask for confirmation.
 
 ### Step 9: Open PR (only after user confirms)
 
-If user confirms:
+If user confirms, push and create PR based on access level:
+
+**For contributors (WRITE/MAINTAIN/ADMIN permission):**
 ```bash
 git push -u origin vuln/{slug}
 gh pr create --title "Add {title}" --body "## Summary
+- **Vulnerability**: {title}
+- **Severity**: {severity}
+- **Source**: {primary_source_url}
+
+## Entry Status
+Stub (AI-Generated) - requires human review before finalizing.
+
+## Caveats
+{any_concerns_or_notes}
+
+---
+Generated with Claude Code"
+```
+
+**For non-contributors (using fork):**
+```bash
+# Get the GitHub username
+GH_USER=$(gh api user --jq '.login')
+
+# Push to fork
+git push -u fork vuln/{slug}
+
+# Create PR from fork to upstream
+gh pr create --repo wiz-sec/open-cvdb \
+  --head "${GH_USER}:vuln/{slug}" \
+  --title "Add {title}" \
+  --body "## Summary
 - **Vulnerability**: {title}
 - **Severity**: {severity}
 - **Source**: {primary_source_url}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+The Open Cloud Vulnerability & Security Issue Database (cloudvulndb.org) - a community-maintained catalog of cloud provider (CSP) security vulnerabilities and issues. Changes merged to main are automatically reflected on the website.
+
+## Repository Structure
+
+- `vulnerabilities/` - YAML files documenting individual vulnerabilities (282+ entries)
+- `pages/` - Static content pages and the `sample.yaml` template
+- `images/` - Images referenced by vulnerability entries
+
+## YAML Schema
+
+Each vulnerability file follows this structure (see `pages/sample.yaml` for template):
+
+```yaml
+title: Human-readable title
+slug: url-friendly-identifier  # Must match filename without .yaml
+cves:
+  - CVE-YYYY-NNNNN  # Empty array [] if none
+affectedPlatforms:
+  - aws | azure | gcp | github | gitlab  # Lowercase
+affectedServices:
+  - Service Name
+image: https://...  # Or path to images/[slug].jpg
+severity: critical | high | medium | low  # Or null
+piercingIndexVector: {version: 1.5, A1: 22, A2: 1, ...}  # Optional
+discoveredBy:
+  name: Researcher Name
+  org: Organization
+  domain: https://...
+  twitter: @handle or URL
+publishedAt: YYYY/mm/dd
+disclosedAt: YYYY/mm/dd
+exploitabilityPeriod: null  # Or description
+knownITWExploitation: true | false | null
+summary: |
+  Multi-line description of the vulnerability
+manualRemediation: |
+  Steps customers should take, or "None required"
+detectionMethods: |
+  How to detect exploitation, or "None" or null
+contributor: https://github.com/username
+references:
+  - https://...  # At least one required
+entryStatus: Stub | Stub (AI-Generated) | Finalized
+```
+
+## Contribution Guidelines
+
+1. Use `Finalized` for complete entries; `Stub` or `Stub (AI-Generated)` for incomplete
+2. The `slug` must match the filename (e.g., `my-vuln.yaml` has `slug: my-vuln`)
+3. Include at least one public reference URL
+4. Give credit to researchers in the `discoveredBy` block
+5. Use respectful language - no disparaging CSPs, vendors, or researchers
+6. Severity can be estimated or derived from the [Piercing Index](https://github.com/piercing-index/cloud-vulnerabilities)
+
+## Distilling Sources into YAML
+
+When converting security research blog posts or vendor bulletins into entries:
+
+### Source Types
+- **Security researcher blogs** (primary source with technical details)
+- **Vendor security bulletins** (AWS Security Bulletins, GCP Support Bulletins, MSRC)
+- **CVE records** (for CVE IDs and descriptions)
+
+### Field Extraction Guidelines
+
+**title**: Use the vulnerability's name if it has one (e.g., "Synlapse", "ConfusedFunction"). Otherwise, create a concise descriptive title like "GCP Cloud Functions Privilege Escalation Vulnerability".
+
+**summary**: 3-5 sentences maximum. Include:
+- What the vulnerability was (the flaw itself)
+- What services/components were affected
+- What the potential impact was
+- Whether/how it was fixed
+- Avoid exploitation steps or technical implementation details
+
+**publishedAt**: Date the blog post or security bulletin was published (not when you're adding it).
+
+**disclosedAt**: When the researcher reported to the vendor. Look for "Timeline" sections, "Responsible Disclosure" notes, or phrases like "reported on X date".
+
+**exploitabilityPeriod**: Extract from timelines. Use formats like "Until YYYY/mm/dd" (when fix deployed) or "YYYY/mm/dd to YYYY/mm/dd" (specific window).
+
+**severity**: Infer from impact if not stated:
+- Cross-tenant access, RCE, global admin = `critical`
+- Privilege escalation, authorization bypass = `high`
+- Information disclosure, logging gaps = `medium`
+- Limited scope issues = `low`
+
+**discoveredBy**: Look for:
+- Author bylines at top/bottom of blog posts
+- "About the Author" sections
+- Acknowledgment sections in vendor bulletins
+- Use `org` without `name` if only company is credited
+
+**manualRemediation**: Focus on customer actions:
+- "None required" if CSP fully remediated server-side
+- Specific version upgrades (e.g., "Update to version X.Y.Z or later")
+- Configuration changes customers should make
+- Workarounds if patches aren't available
+
+**detectionMethods**: Include when available:
+- KQL/SQL queries from the research (verbatim)
+- CloudTrail event names to monitor
+- Version checks to identify vulnerable installations
+- Use "None" if no practical detection exists
+
+**references**: Order by importance:
+1. Primary technical writeup (researcher's blog)
+2. Vendor security bulletin/acknowledgment
+3. CVE record link
+4. AWS/GCP/Azure documentation if relevant
+
+### Quality Checklist
+- Platforms are lowercase: `aws`, `azure`, `gcp`, `github`, `gitlab`
+- Domain field is bare domain without `https://` prefix
+- Empty fields use `null` not `- null` or empty strings
+- Dates use `YYYY/mm/dd` format
+- CVEs array is `[]` if none, not `null`


### PR DESCRIPTION
## Summary
Adds three Claude Code skills for managing open-cvdb vulnerability entries:

1. **vulnerability** - Create/edit individual vulnerability entries with quality checks
2. **hunt** - Proactively discover new vulnerabilities from authoritative sources
3. **triage-issues** - Process open GitHub issues requesting additions

## Updates from #465
- Fixed fork remote configuration (ramimac vs rami-wiz)
- Added NVD API enrichment for MSRC CVEs (better descriptions than raw CVRF)
- Added explicit duplicate prevention checks (check ALL open PRs, not just own author)

## Duplicate Prevention
The hunt skill now explicitly checks:
- Existing entries in repo via grep
- ALL open PRs regardless of author
- Open issues with addition label

This prevents creating duplicates when fork accounts change between sessions.

Supersedes #465

---
Generated with Claude Code