### PR TITLE
Add CVE-2026-23658: Azure DevOps Privilege Escalation

### DIFF
--- a/vulnerabilities/azure-devops-credential-privesc.yaml
+++ b/vulnerabilities/azure-devops-credential-privesc.yaml
@@ -1,0 +1,28 @@
+title: Azure DevOps Insufficiently Protected Credentials Privilege Escalation
+slug: azure-devops-credential-privesc
+cves:
+  - CVE-2026-23658
+affectedPlatforms:
+  - azure
+affectedServices:
+  - Azure DevOps
+severity: high
+piercingIndexVector:
+discoveredBy:
+  name: null
+  org: null
+  domain: null
+  twitter:
+publishedAt: 2026/03/20
+disclosedAt: 2026/03/20
+exploitabilityPeriod: null
+knownITWExploitation: false
+summary: |
+  An insufficiently protected credentials vulnerability in Microsoft Azure DevOps allows an unauthorized attacker to elevate privileges over a network. The vulnerability stems from improper credential protection mechanisms within the Azure DevOps service.
+manualRemediation: |
+  No customer action is required. Microsoft has patched this vulnerability server-side.
+detectionMethods: null
+contributor: https://github.com/vanhoangkha
+references:
+  - https://www.sentinelone.com/vulnerability-database/cve-2026-23658/
+entryStatus: Finalized


### PR DESCRIPTION
Adds **CVE-2026-23658** — Azure DevOps insufficiently protected credentials allow privilege escalation.
- **Platform:** Azure | **Service:** Azure DevOps | **Severity:** HIGH
- https://www.sentinelone.com/vulnerability-database/cve-2026-23658/